### PR TITLE
Fix category parsing and translation

### DIFF
--- a/src/MenuPage.js
+++ b/src/MenuPage.js
@@ -15,12 +15,20 @@ export default function MenuPage() {
       header: true,
       complete: (results) => {
         const data = results.data;
-        const availableItems = data.filter(item => item.Available?.toLowerCase() === "true");
+        const availableItems = data
+          .filter(item => item.Available?.toLowerCase() === "true")
+          .map(item => ({
+            ...item,
+            Category: item.Category?.trim() || "",
+          }));
+
         setItems(availableItems);
 
-        const uniqueCategories = [...new Set(availableItems.map(i => i.Category))];
+        const uniqueCategories = [
+          ...new Set(availableItems.map(i => i.Category).filter(Boolean)),
+        ];
         setCategories(uniqueCategories);
-      }
+      },
     });
   }, []);
 
@@ -88,7 +96,8 @@ function translateCategory(grCategory) {
     "ΠΙΑΤΑ ΤΗΣ ΩΡΑΣ": "COOKED TO ORDER",
     "ΑΝΑΨΥΚΤΙΚΑ-ΜΠΥΡΕΣ": "REFRESHMENTS-BEERS",
     "ΚΡΑΣΙ": "WINE",
-    "ΠΟΤΑ": "DRINKS"
+    "ΠΟΤΑ": "DRINKS",
   };
-  return dictionary[grCategory] || grCategory;
+  const key = grCategory.trim().toUpperCase();
+  return dictionary[key] || grCategory.trim();
 }


### PR DESCRIPTION
## Summary
- trim category values when parsing CSV
- filter out blank categories
- normalize Greek category names before translating

## Testing
- `npm test --silent --yes` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847edacfd5083248cdb55af91d2ba44