### PR TITLE
fix: ignore whitespace in Available column

### DIFF
--- a/src/MenuPage.js
+++ b/src/MenuPage.js
@@ -16,7 +16,7 @@ export default function MenuPage() {
       complete: (results) => {
         const data = results.data;
         const availableItems = data
-          .filter(item => item.Available?.toLowerCase() === "true")
+          .filter(item => item.Available?.trim().toLowerCase() === "true")
           .map(item => ({
             ...item,
             Category: item.Category?.trim() || "",


### PR DESCRIPTION
## Summary
- trim whitespace before checking availability flag

## Testing
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847f49728f88324973963aa20363351